### PR TITLE
st_area failing - turned off spherical geometry

### DIFF
--- a/R/get_area.R
+++ b/R/get_area.R
@@ -37,6 +37,9 @@ get_area <- function(areaPolygon, areaDescription){
   # system
   crs = "+proj=lcc +lat_1=20 +lat_2=60 +lat_0=40 +lon_0=-72 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs +ellps=GRS80 +towgs84=0,0,0"
 
+  # turn off spherical geometry. Causes an issue in st_area function
+  sf::sf_use_s2(FALSE)
+
   Area <- units::set_units(sf::st_area(areaPolygon, crs),km^2)
 
   strata <- areaPolygon %>%


### PR DESCRIPTION
calc_swept_area is failing when using the default `strata.shp` shapefile due to an error in `sf::st_area` 

Remedied by turning off spherical geometry as recommended by Edzer https://github.com/r-spatial/sf/issues/1762