### PR TITLE
Changed SE calc to sqrt(S^2) from sqrt(S^2/N)

### DIFF
--- a/R/strat_mean.R
+++ b/R/strat_mean.R
@@ -127,8 +127,8 @@ strat_mean <- function (prepData, groupDescription = "SVSPP", filterByGroup = "a
   }
 
   #standard error of the means
-  stratmeanData[, biomass.SE := sqrt(biomass.var / N), by = key(stratmeanData)]
-  stratmeanData[, abund.SE   := sqrt(abund.var / N),   by = key(stratmeanData)]
+  stratmeanData[, biomass.SE := sqrt(biomass.var), by = key(stratmeanData)]
+  stratmeanData[, abund.SE   := sqrt(abund.var),   by = key(stratmeanData)]
 
   #Delete extra rows/columns
   stratmeanData <- unique(stratmeanData, by = key(stratmeanData))

--- a/vignettes/calc_strat_mean.Rmd
+++ b/vignettes/calc_strat_mean.Rmd
@@ -216,7 +216,7 @@ The final calculation for the `calc_stratified_mean` function is the standard er
 
 \begin{equation}
     \label{standard error}
-    s_{\bar{B}} = \sqrt{\frac{s_{\bar{B}}^2}{N}}
+    s_{\bar{B}} = \sqrt{s_{\bar{B}}^2}
 \end{equation}
 
 Similar calculations are carried out for abundance with numbers replacing biomass in the equations above.


### PR DESCRIPTION
After discussing with Sarah and based on need for SOE, I decided that the Standard Error calculation should be `SE = sqrt(S^2)` rather than `SE = sqrt(S^2 / N)`.  Issue is really a sloppy definition of Standard Error verses Standard Deviation.  However, everything I've found on line seems to confirm that this is the calculation that is used.