### PR TITLE
swept area bug fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: survdat
 Type: Package
 Title: Tools for working with NEFSC survey data
-Version: 1.1.0
+Version: 1.1.1
 Authors@R: c(person(given = "Sean",
                     family = "Lucey",
                     email = "Sean.Lucey@NOAA.gov",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: survdat
 Type: Package
 Title: Tools for working with NEFSC survey data
-Version: 1.0.1
+Version: 1.1.0
 Authors@R: c(person(given = "Sean",
                     family = "Lucey",
                     email = "Sean.Lucey@NOAA.gov",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,6 @@ Authors@R: c(person(given = "Sean",
                    role = c("aut","cre"),
                    comment = c(ORCID = "0000-0001-8270-7090")))
 License: file LICENSE
-Roxygen: list(markdown = TRUE)
 Encoding: UTF-8
 Description: A collection of functions for use with NEFSC survey data.  Functions
   will generate stratified means and swept area estimates from the surveys.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# survdat 1.1.1
+
+## Bug fixes
+
+* `calc_swept_area` function can now use a user supplied value of `a` (average swept area of trawl, km^-2)
+* `swep_area` function can now utilize a user supplied scalar for `q` (catchability) across all groups
+
 # survdat 1.1.0
 
 * Added `get_species_stock_area` function to retrieve species stock area (Bottom Trawl survey STRATA) data from STOCKEFF

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# survdat 1.1.0
+
+* Added `get_species_stock_area` function to retrieve species stock area (Bottom Trawl survey STRATA) data from STOCKEFF
+
 # survdat 1.0.1
 
 Representative tows are now being pulled differently. 


### PR DESCRIPTION
* `calc_swept_area` function can now use a user supplied value of `a` (average swept area of trawl, km^-2)
* `swep_area` function can now utilize a user supplied scalar for `q` (catchability) across all groups
