### PR TITLE
docs(#96): replaced representative tows with correct TOGA defintion

### DIFF
--- a/vignettes/pullingData.Rmd
+++ b/vignettes/pullingData.Rmd
@@ -28,7 +28,7 @@ Species abundance (EXPCATCHNUM), biomass (EXPCATCHWT), and sex (CATCHSEX), for e
 A representative tow is a tow with:
 
  * SHG code <= 136 for tows on cruises on or before 2009 and 
- * TOGA code <= 1324 for tows on cruises after 2009
+ * TOGA code: T (type) <= 1 and O (operation) <= 3 and G (gear) <= 2 for tows on cruises after 2009
 
 ```{r pull1, echo =TRUE, eval = F}
 survdat::get_survdat_data(channel, 
@@ -55,7 +55,7 @@ select unique cruise6, svvessel, station, stratum, tow, decdeg_beglat as lat, de
 from svdbs.UNION_FSCS_SVSTA
 where cruise6 in <cruiseData>
 and (SHG <= 136 and cruise6 <= 200900)
-or (TOGA <= 1324 and cruise6 > 200900)
+or (type_code <= 1 and operation_code <= 3 and gear_code <= 2 and cruise6 > 200900)
 order by cruise6, station)
 
 ```


### PR DESCRIPTION
Your commits explain the `who`, `what`, `where` and `when` of these changes. Your code shows the `how`. You do not need to reiterate this. This PR should complete the big picture by telling the `why`.

### Justification

The definition of a representative tow based on the TOGA code was described incorrectly in the documentation. It had been changed in the underlying code but not in the docs. This PR addressed the doc changes.

fixes #96 

### Types of changes

What types of changes does your code introduce? Put an `x` in the boxes that apply

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other change (if none of the other choices apply) 

### Reviewer instructions:

Brief review of documentation changes

