### PR TITLE
Fix(#107): avoids use of `lwgeom` package for area estimation

### DIFF
--- a/R/get_area.R
+++ b/R/get_area.R
@@ -13,9 +13,9 @@
 #'\item{AREA}{The area of the STRATA in square kilometers}
 #'
 #'@section Coordinate reference system (CRS):
-#'The deafult CRS is the Lambert Conformal Conic as is denoted by :
+#'The deafult CRS is the Albers Equal Area as is denoted by :
 #'
-#'"+proj=lcc +lat_1=20 +lat_2=60 +lat_0=40 +lon_0=-72 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs +ellps=GRS80 +towgs84=0,0,0 "
+#'"+proj=aea +lat_1=20 +lat_2=60 +lat_0=40 +lon_0=-72 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs +ellps=GRS80 +towgs84=0,0,0 "
 #'
 #'@importFrom magrittr "%>%"
 #'
@@ -33,14 +33,25 @@
 get_area <- function(areaPolygon, areaDescription) {
   # Find area of polygons based on a lambert conformal conic coordinate reference
   # system
-  crs = "+proj=lcc +lat_1=20 +lat_2=60 +lat_0=40 +lon_0=-72 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs +ellps=GRS80 +towgs84=0,0,0"
+  #crs <- "+proj=lcc +lat_1=20 +lat_2=60 +lat_0=40 +lon_0=-72 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs +ellps=GRS80 +towgs84=0,0,0"
+  # original custom CRS (+proj=lcc) was Conformal (it preserves shapes, but
+  # distorts area). By changing it to +proj=aea (Equal-Area)
+  # while keeping the exact same latitude/longitude center points,
+  # the flat 2D math calculated by sf::st_area() will now match
+  # the true ellipsoidal lwgeom values
+  crs <- "+proj=aea +lat_1=20 +lat_2=60 +lat_0=40 +lon_0=-72 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs +ellps=GRS80 +towgs84=0,0,0"
 
   # turn off spherical geometry. Causes an issue in st_area function
   sf::sf_use_s2(FALSE)
+  # Repair any invalid geometries (resolves the duplicate vertex error)
+  areaPolygon_clean <- sf::st_make_valid(areaPolygon)
+  area_projected <- sf::st_transform(areaPolygon_clean, crs)
 
-  Area <- units::set_units(sf::st_area(areaPolygon, crs), km^2)
+  # bypass units package check and assign km^2 manually
+  raw_meters <- as.numeric(sf::st_area(area_projected))
+  Area <- units::set_units(raw_meters / 1000000, "km^2")
 
-  strata <- areaPolygon %>%
+  strata <- areaPolygon_clean %>%
     as.data.frame() %>%
     dplyr::select(areaDescription) %>%
     dplyr::rename(STRATUM = areaDescription) %>%

--- a/man/get_area.Rd
+++ b/man/get_area.Rd
@@ -23,9 +23,9 @@ Calculates the area of a polygon from a shapefile.
 }
 \section{Coordinate reference system (CRS)}{
 
-The deafult CRS is the Lambert Conformal Conic as is denoted by :
+The deafult CRS is the Albers Equal Area as is denoted by :
 
-"+proj=lcc +lat_1=20 +lat_2=60 +lat_0=40 +lon_0=-72 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs +ellps=GRS80 +towgs84=0,0,0 "
+"+proj=aea +lat_1=20 +lat_2=60 +lat_0=40 +lon_0=-72 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs +ellps=GRS80 +towgs84=0,0,0 "
 }
 
 \examples{


### PR DESCRIPTION

### Justification

`survdat` currently avoids `sf`s use of `s2` geometry (assumes a spherical earth). When this is turned off, as in `survdat` , `sf` resorts to calculating area of a shapefile from lat and lon values by using the `lwgeom` package. By `sf` design, `lwgeom` is not listed as a dependency of its package. This results in errors in `survdat` since it isnt a dependency of `survdat` either. Rather than listing another unnecessary dependency a work around is implemented.

Fixes #107 

### Types of changes

What types of changes does this pull request introduce? Put an `x` in the boxes that apply.
This will inform the new release number.

- [x] Fix (non-breaking change which fixes a bug)
- [ ] Feature (non-breaking change which adds or changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other change (if none of the other choices apply)

### Reviewer instructions

Run the example in the `get_area()` function under this branch and in `dev` to confirm the method changes produce the same result. These calculations are also used in `calc_swept_area()` so running this from both branches will be an additional test.

### Formatting

This repo contains an `air.toml` file that automatically formats code to a set of standards.
It is preferred that contributors and reviewers install the [Air](https://posit-dev.github.io/air/) formatting tool.
Code submitted in this pull request will be automatically checked for correct formatting.
