### PR TITLE
Feature(#114): Remove printing of intermediate data

### DIFF
--- a/R/strat_prep.R
+++ b/R/strat_prep.R
@@ -91,7 +91,6 @@ strat_prep <- function(
       }
     }
   }
-  print(filterByArea)
 
   filteredData <- surveyData[
     SEASON %in% filterBySeason & get(areaDescription) %in% filterByArea,

--- a/R/swept_area.R
+++ b/R/swept_area.R
@@ -60,11 +60,13 @@ swept_area <- function(
 
   #Merge q
   if (is.null(q)) {
+    # set q = 1 for all groups
+    q_value <- 1
     q <- data.table::data.table(
       groups = unique(swept.area[, get(groupDescription)]),
-      q = 1
+      q = q_value
     )
-    message("Assuming a value of q = ", q, " for all groups")
+    message("Assuming a value of q = ", q_value, " for all groups")
   } else if (length(q) == 1) {
     # apply q to all groups
     message("Assuming a value of q = ", q, " for all groups")


### PR DESCRIPTION
### Justification

When running `calc_swept_area()` a list of strata are printed to the console. In addition a table of qs by SVSPP is printed when it should just be a scalar. The latter is due to a formatting issue, the former a print statement. Both have been addressed

Fixes #114 

### Types of changes

What types of changes does this pull request introduce? Put an `x` in the boxes that apply.
This will inform the new release number.

- [ ] Fix (non-breaking change which fixes a bug)
- [x] Feature (non-breaking change which adds or changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other change (if none of the other choices apply)

### Reviewer instructions

Two steps, pull data, then run function.
* connect to the database to create a `channel` object
* get data - `data <- survdat::get_survdat_data(channel, getLengths = FALSE)`
*  Run `calc_swept_area(data$survdat, filterBySeason = "SPRING")` on this branch and the `dev` branch to see the differences
Note: The air check fails. This has been addressed in PR #111
 
### Formatting

This repo contains an `air.toml` file that automatically formats code to a set of standards.
It is preferred that contributors and reviewers install the [Air](https://posit-dev.github.io/air/) formatting tool.
Code submitted in this pull request will be automatically checked for correct formatting.
